### PR TITLE
Adding System V init script

### DIFF
--- a/SystemV/acfix
+++ b/SystemV/acfix
@@ -1,0 +1,36 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          acfix
+# Required-Start:
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Execute workaround for Acer Predator Helios Ryzen AC ACPI/BIOS issue
+# Description:       Github repo https://github.com/pastaq/Acer-Ryzen-Helios-AC-Fix
+### END INIT INFO
+
+PATH=/usr/local/sbin
+
+. /lib/lsb/init-functions
+
+do_start () {
+	log_action_msg "Executing Helios 500 Ryzen AC workaround..."
+	exec /usr/local/sbin/acfix.sh
+}
+
+case "$1" in
+  start)
+	do_start
+	;;
+  restart|reload|force-reload)
+	echo "Error: argument '$1' not supported" >&2
+	exit 3
+	;;
+  stop|status)
+	# No-op
+	;;
+  *)
+	echo "Usage: $0 start|stop" >&2
+	exit 3
+	;;
+esac


### PR DESCRIPTION
Fixes #3 
Installation:
1. Place the acfix.sh into /usr/local/sbin as with systemd
2. Copy the acfix System V init script into /etc/init.d
3. `chown root:staff /etc/init.d/acfix` (or whichever group is your root in, maybe root:root)
4. Run `update-rc.d acfix defaults`